### PR TITLE
Add the required `protocol` field to the container ports of the deployment resource

### DIFF
--- a/components/componentA/base/deployment-sample-workload.yaml
+++ b/components/componentA/base/deployment-sample-workload.yaml
@@ -28,3 +28,4 @@ spec:
 
         ports:
         - containerPort: 8080
+          protocol: TCP

--- a/components/componentB/base/deployment-sample-workload.yaml
+++ b/components/componentB/base/deployment-sample-workload.yaml
@@ -28,3 +28,4 @@ spec:
 
         ports:
         - containerPort: 8080
+          protocol: TCP


### PR DESCRIPTION
Add the required `protocol` field to the container ports of the deployment resource. 